### PR TITLE
feat: props onto div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,8 +160,8 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
       // This can result in invalid style values which can result in NaN values if we don't handle them.
       // See issue #150 for more context.
 
-      const height = this._parentNode.offsetHeight || 0;
-      const width = this._parentNode.offsetWidth || 0;
+
+      const { height = 0, width = 0} = this._parentNode.getBoundingClientRect();
 
       const style = window.getComputedStyle(this._parentNode) || {};
       const paddingLeft = parseInt(style.paddingLeft, 10) || 0;

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export default class AutoSizer extends React.PureComponent<Props, State> {
           ...outerStyle,
           ...style,
         }}
-      >
+      {...this.props}>
         {!bailoutOnChildren && children(childParams)}
       </div>
     );

--- a/src/vendor/detectElementResize.js
+++ b/src/vendor/detectElementResize.js
@@ -251,6 +251,9 @@ export default function createDetectElementResize(nonce) {
     if (attachEvent) {
       element.detachEvent('onresize', fn);
     } else {
+			if (!element.__resizeListeners__) {
+        return;
+      }
       element.__resizeListeners__.splice(
         element.__resizeListeners__.indexOf(fn),
         1


### PR DESCRIPTION
Spread props onto div
This allows users of the libraray to pass a tabIndex prop to avoid a11y accessibility guidance violations.
https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable?application=axeAPI